### PR TITLE
feat: advertise HTTP service via mDNS for Home Assistant discovery

### DIFF
--- a/src/wifi/wifi_manager.cpp
+++ b/src/wifi/wifi_manager.cpp
@@ -188,6 +188,7 @@ int WifiManager::getStatus() const {
 
 bool WifiManager::setupMDNS(const char* hostname) {
     if (MDNS.begin(hostname)) {
+        MDNS.addService("http", "tcp", 80);
         return true;
     } else {
         return false;


### PR DESCRIPTION
## Summary

- Adds `MDNS.addService("http", "tcp", 80)` after `MDNS.begin()` in `wifi_manager.cpp`

## Why

Currently `MDNS.begin()` registers the hostname (`zap.local`) but does not advertise the HTTP service. Home Assistant's [zeroconf integration](https://www.home-assistant.io/integrations/zeroconf/) discovers devices by listening for `_http._tcp.local.` service announcements. Without this service advertisement, the Zap gateway is invisible to HA auto-discovery.

## What it does

After this change, the Zap gateway will broadcast itself as an HTTP service on the local network. This enables Home Assistant (and other mDNS-aware tools) to automatically detect and offer to configure the device — no manual IP entry needed.

## Testing

- Verified `MDNS.addService()` is the standard ESP32 Arduino API for service advertisement
- The HA integration already has the matching zeroconf filter in `manifest.json`:
  ```json
  {"type": "_http._tcp.local.", "name": "zap*.local"}
  ```